### PR TITLE
Z-LAC-0003: Time wrapper

### DIFF
--- a/src/zcl_lac_time_wrap.clas.abap
+++ b/src/zcl_lac_time_wrap.clas.abap
@@ -1,0 +1,59 @@
+class ZCL_LAC_TIME_WRAP definition
+  public
+  final
+  create public .
+
+public section.
+
+  interfaces ZIF_LAC_TIME_WRAP .
+protected section.
+private section.
+ENDCLASS.
+
+
+
+CLASS ZCL_LAC_TIME_WRAP IMPLEMENTATION.
+
+
+  METHOD zif_lac_time_wrap~convert_time_to_external.
+
+    TRY .
+        cl_abap_timefm=>conv_time_int_to_ext(
+          EXPORTING
+            time_int            = iv_time
+            without_seconds     = ib_without_seconds
+            format_according_to = cl_abap_timefm=>environment
+          IMPORTING
+            time_ext            = rv_time
+        ).
+
+      CATCH cx_parameter_invalid_range.
+        RAISE EXCEPTION TYPE zcx_lac_time_conversion_error
+          EXPORTING
+            mv_internal_time = iv_time
+            textid           = zcx_lac_time_conversion_error=>to_external.
+    ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD zif_lac_time_wrap~convert_time_to_internal.
+
+    TRY .
+        cl_abap_timefm=>conv_time_ext_to_int(
+          EXPORTING
+            time_ext      = iv_time
+            is_24_allowed = ib_24_allowed
+          IMPORTING
+          time_int      = rv_time
+        ).
+
+      CATCH cx_abap_timefm_invalid.
+        RAISE EXCEPTION TYPE zcx_lac_time_conversion_error
+          EXPORTING
+            mv_external_time = iv_time
+            textid           = zcx_lac_time_conversion_error=>to_internal.
+    ENDTRY.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcl_lac_time_wrap.clas.xml
+++ b/src/zcl_lac_time_wrap.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_LAC_TIME_WRAP</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>LAC Date FM Wrapper</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcx_lac_time_conversion_error.clas.abap
+++ b/src/zcx_lac_time_conversion_error.clas.abap
@@ -1,0 +1,59 @@
+class ZCX_LAC_TIME_CONVERSION_ERROR definition
+  public
+  inheriting from ZCX_LAC
+  final
+  create public .
+
+public section.
+
+  constants:
+    begin of TO_EXTERNAL,
+      msgid type symsgid value 'ZLAC',
+      msgno type symsgno value '017',
+      attr1 type scx_attrname value 'MV_INTERNAL_DATE',
+      attr2 type scx_attrname value '',
+      attr3 type scx_attrname value '',
+      attr4 type scx_attrname value '',
+    end of TO_EXTERNAL .
+  constants:
+    begin of TO_INTERNAL,
+      msgid type symsgid value 'ZLAC',
+      msgno type symsgno value '018',
+      attr1 type scx_attrname value 'MV_EXTERNAL_DATE',
+      attr2 type scx_attrname value '',
+      attr3 type scx_attrname value '',
+      attr4 type scx_attrname value '',
+    end of TO_INTERNAL .
+  data MV_EXTERNAL_TIME type STRING .
+  data MV_INTERNAL_TIME type T .
+
+  methods CONSTRUCTOR
+    importing
+      !TEXTID like IF_T100_MESSAGE=>T100KEY optional
+      !PREVIOUS like PREVIOUS optional
+      !MV_EXTERNAL_TIME type STRING optional
+      !MV_INTERNAL_TIME type T optional .
+protected section.
+private section.
+ENDCLASS.
+
+
+
+CLASS ZCX_LAC_TIME_CONVERSION_ERROR IMPLEMENTATION.
+
+
+  method CONSTRUCTOR.
+CALL METHOD SUPER->CONSTRUCTOR
+EXPORTING
+PREVIOUS = PREVIOUS
+.
+me->MV_EXTERNAL_TIME = MV_EXTERNAL_TIME .
+me->MV_INTERNAL_TIME = MV_INTERNAL_TIME .
+clear me->textid.
+if textid is initial.
+  IF_T100_MESSAGE~T100KEY = IF_T100_MESSAGE=>DEFAULT_TEXTID.
+else.
+  IF_T100_MESSAGE~T100KEY = TEXTID.
+endif.
+  endmethod.
+ENDCLASS.

--- a/src/zcx_lac_time_conversion_error.clas.xml
+++ b/src/zcx_lac_time_conversion_error.clas.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCX_LAC_TIME_CONVERSION_ERROR</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>LAC Date Conversion Exception</DESCRIPT>
+    <CATEGORY>40</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCX_LAC_TIME_CONVERSION_ERROR</CLSNAME>
+     <CMPNAME>CONSTRUCTOR</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>CONSTRUCTOR</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zif_lac_time_wrap.intf.abap
+++ b/src/zif_lac_time_wrap.intf.abap
@@ -1,0 +1,21 @@
+interface ZIF_LAC_TIME_WRAP
+  public .
+
+
+  methods CONVERT_TIME_TO_INTERNAL
+    importing
+      !IV_TIME type CSEQUENCE
+      !IB_24_ALLOWED type ABAP_BOOL default ABAP_FALSE
+    returning
+      value(RV_TIME) type T
+    raising
+      ZCX_LAC_TIME_CONVERSION_ERROR .
+  methods CONVERT_TIME_TO_EXTERNAL
+    importing
+      !IV_TIME type T
+      !IB_WITHOUT_SECONDS type ABAP_BOOL default ABAP_FALSE
+    returning
+      value(RV_TIME) type STRING
+    raising
+      ZCX_LAC_TIME_CONVERSION_ERROR .
+endinterface.

--- a/src/zif_lac_time_wrap.intf.xml
+++ b/src/zif_lac_time_wrap.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_LAC_TIME_WRAP</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>LAC: Time Class Wrapper</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zlac.msag.xml
+++ b/src/zlac.msag.xml
@@ -110,6 +110,18 @@
      <MSGNR>016</MSGNR>
      <TEXT>Missing implementation of handler &amp;1 type &amp;2</TEXT>
     </T100>
+    <T100>
+     <SPRSL>E</SPRSL>
+     <ARBGB>ZLAC</ARBGB>
+     <MSGNR>017</MSGNR>
+     <TEXT>&amp; is invalid. Please specify a valid internal time in format &apos;HHMMSS&apos;.</TEXT>
+    </T100>
+    <T100>
+     <SPRSL>E</SPRSL>
+     <ARBGB>ZLAC</ARBGB>
+     <MSGNR>018</MSGNR>
+     <TEXT>Time &amp; is invalid. Specify a time in format &apos;HH:MM:SS&apos;</TEXT>
+    </T100>
    </T100>
   </asx:values>
  </asx:abap>


### PR DESCRIPTION
Classes:
- zif_lac_time_wrap
- zcl_lac_time_wrap
- zcx_lac_time_conversion_error

Message:
- zlac > 017

## :triangular_flag_on_post: Checklist 

- [ ] No ATC Check 
- [ ] Extended Check - No Errors or Warnings (selection with all fields selected)
- [ ] Code Inspector - No Errors or Warnings 
- [ ] Unit Test above `80%` of statement coverage
- [ ] The use of exceptions are well made
- [ ] Design patterns are well implemented
- [ ] There is documentation for my code.

### :speech_balloon: Comments
none
